### PR TITLE
add extraProperties for named parameter validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ test:
 	node test/basic.js
 	node test/validate.js
 	node test/hrtimediff.js
+	node test/extraprops.js
 	@echo tests okay
 
 include ./Makefile.targ

--- a/README.md
+++ b/README.md
@@ -157,6 +157,15 @@ schema.  On success, returns null.  On failure, *returns* (does not throw) a
 useful Error object.
 
 
+### extraProperties(object, allowed)
+
+Check an object for unexpected properties.  Accepts the object to check, and an
+array of allowed property name strings.  If extra properties are detected, an
+array of extra property names is returned.  If no properties other than those
+in the allowed list are present on the object, the returned array will be of
+zero length.
+
+
 # Contributing
 
 Code should be "make check" clean.  This target assumes that

--- a/lib/jsprim.js
+++ b/lib/jsprim.js
@@ -26,6 +26,7 @@ exports.validateJsonObjectJS = validateJsonObjectJS;
 exports.validateJsonObjectJSV = validateJsonObjectJSV;
 exports.randElt = randElt;
 exports.hrtimediff = hrtimediff;
+exports.extraProperties = extraProperties;
 
 exports.startsWith = startsWith;
 exports.endsWith = endsWith;
@@ -352,4 +353,27 @@ function hrtimediff(a, b)
 	}
 
 	return (rv);
+}
+
+/*
+ * Check an object for unexpected properties.  Accepts the object to check, and
+ * an array of allowed property names (strings).  Returns an array of key names
+ * that were found on the object, but did not appear in the list of allowed
+ * properties.  If no properties were found, the returned array will be of
+ * zero length.
+ */
+function extraProperties(obj, allowed)
+{
+	mod_assert.ok(typeof (obj) === 'object' && obj !== null,
+	    'obj argument must be a non-null object');
+	mod_assert.ok(Array.isArray(allowed),
+	    'allowed argument must be an array of strings');
+	for (var i = 0; i < allowed.length; i++) {
+		mod_assert.ok(typeof (allowed[i]) === 'string',
+		    'allowed argument must be an array of strings');
+	}
+
+	return (Object.keys(obj).filter(function (key) {
+		return (allowed.indexOf(key) === -1);
+	}));
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jsprim",
-	"version": "0.7.0",
+	"version": "0.8.0",
 	"description": "utilities for primitive JavaScript types",
 	"main": "./lib/jsprim.js",
 	"repository": {

--- a/test/extraprops.js
+++ b/test/extraprops.js
@@ -1,0 +1,113 @@
+/*
+ * extraprops.js: test extraProperties() function
+ */
+
+var mod_assert = require('assert');
+var mod_util = require('util');
+var mod_jsprim = require('../lib/jsprim');
+
+var extraProperties = mod_jsprim.extraProperties;
+
+var test_cases = [
+	{
+		obj: null,
+		allowed: [
+			'one',
+			'two'
+		],
+		expectedThrow: 'obj argument must be a non-null object'
+	},
+	{
+		obj: {
+			charlie: 'horse'
+		},
+		allowed: [
+			'charlie',
+			5
+		],
+		expectedThrow: 'allowed argument must be an array of strings'
+	},
+	{
+		obj: {
+			charlie: 'horse'
+		},
+		allowed: {
+			charlie: true
+		},
+		expectedThrow: 'allowed argument must be an array of strings'
+	},
+	{
+		obj: {
+			strict: true,
+			hapless: true,
+			quality: -3
+		},
+		allowed: [
+			'strict',
+			'advisable',
+			'decent',
+			'quality'
+		],
+		expected: [
+			'hapless'
+		]
+	},
+	{
+		obj: {},
+		allowed: [],
+		expected: null
+	},
+	{
+		obj: {
+			strict: true,
+			quality: 100
+		},
+		allowed: [
+			'strict',
+			'advisable',
+			'decent',
+			'quality'
+		],
+		expected: []
+	},
+	{
+		obj: {
+			'false': null
+		},
+		allowed: [],
+		expected: [
+			'false'
+		]
+	}
+];
+
+function printf()
+{
+	process.stdout.write(mod_util.format.apply(null, arguments));
+}
+
+test_cases.forEach(function (testcase, idx) {
+	printf('test_cases[%d]:\n', idx);
+	printf('\tobj: %j\n', testcase.obj);
+	printf('\tallowed: %j\n', testcase.allowed);
+
+	var actual;
+	try {
+		actual = extraProperties(testcase.obj, testcase.allowed);
+	} catch (ex) {
+		if (!testcase.expectedThrow) {
+			throw (ex);
+		}
+
+		mod_assert.equal(ex.message, testcase.expectedThrow);
+		return;
+	}
+
+	if (testcase.expectedThrow) {
+		throw (new Error('expected an assertion failure'));
+	}
+
+	if (testcase.expected) {
+		mod_assert.deepEqual(actual, testcase.expected);
+	}
+});


### PR DESCRIPTION
### extraProperties(object, allowed)

Check an object for unexpected properties.  Accepts the object to check, and an
array of allowed property name strings.  If no properties other than those in
the allowed list are present on the object, this function returns `null`.  If
extra properties are detected, an array of extra property names is returned.