### PR TITLE
Removing dependence need to extsprintf

### DIFF
--- a/lib/jsprim.js
+++ b/lib/jsprim.js
@@ -5,7 +5,6 @@
 var mod_assert = require('assert');
 var mod_util = require('util');
 
-var mod_extsprintf = require('extsprintf');
 var mod_verror = require('verror');
 var mod_jsonschema = require('json-schema');
 
@@ -236,24 +235,14 @@ function iso8601(d)
 	if (typeof (d) == 'number')
 		d = new Date(d);
 	mod_assert.ok(d.constructor === Date);
-	return (mod_extsprintf.sprintf('%4d-%02d-%02dT%02d:%02d:%02d.%03dZ',
-	    d.getUTCFullYear(), d.getUTCMonth() + 1, d.getUTCDate(),
-	    d.getUTCHours(), d.getUTCMinutes(), d.getUTCSeconds(),
-	    d.getUTCMilliseconds()));
+	return d.toISOString();
 }
 
-var RFC1123_MONTHS = [
-    'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
-    'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-var RFC1123_DAYS = [
-    'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
-
-function rfc1123(date) {
-	return (mod_extsprintf.sprintf('%s, %02d %s %04d %02d:%02d:%02d GMT',
-	    RFC1123_DAYS[date.getUTCDay()], date.getUTCDate(),
-	    RFC1123_MONTHS[date.getUTCMonth()], date.getUTCFullYear(),
-	    date.getUTCHours(), date.getUTCMinutes(),
-	    date.getUTCSeconds()));
+function rfc1123(d) {
+	if (typeof (d) == 'number')
+		d = new Date(d);
+	mod_assert.ok(d.constructor === Date);
+	return d.toUTCString();
 }
 
 /*


### PR DESCRIPTION
extsprintf was only used in 2 functions : iso8601 & rfc1123. But those 2 functions seems to be reimplementation of natively supported Date methods. 
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString
https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Objets_globaux/Date/toUTCString