### PR TITLE
Removing dependence need to verror

### DIFF
--- a/lib/jsprim.js
+++ b/lib/jsprim.js
@@ -6,7 +6,6 @@ var mod_assert = require('assert');
 var mod_util = require('util');
 
 var mod_extsprintf = require('extsprintf');
-var mod_verror = require('verror');
 var mod_jsonschema = require('json-schema');
 
 /*
@@ -310,8 +309,10 @@ function validateJsonObjectJS(schema, input)
 		reason = 'unsupported property';
 	}
 
-	var rv = new mod_verror.VError('property "%s": %s', propname, reason);
-	rv.jsv_details = error;
+	var rv = {
+		message : 'property "'+propname+'": '+reason,
+		jsv_details : error
+	}
 	return (rv);
 }
 


### PR DESCRIPTION
verror was only used in validateJsonObjectJS to generate an object with 2 fields : message and jsv_details.